### PR TITLE
fix: fix getIncrement issue

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ class CalverPlugin extends Plugin {
     getFormat() {
         return this.getContext().format || DEFAULT_FORMAT;
     }
-    
+
     getIncrementedVersion({latestVersion}) {
         let calver = new Calver(this.getFormat(), latestVersion).inc();
         if (calver.get() === latestVersion) {
@@ -19,6 +19,10 @@ class CalverPlugin extends Plugin {
     }
 
     getIncrementedVersionCI() {
+        return this.getIncrementedVersion(...arguments);
+    }
+
+    getIncrement() {
         return this.getIncrementedVersion(...arguments);
     }
 }


### PR DESCRIPTION
When running the dry-run command I'm getting this error:

```
❯ yarn release --dry-run
yarn run v1.22.4
$ release-it --dry-run
$ git rev-parse --abbrev-ref HEAD
$ git config --get branch.master.remote
$ git remote get-url origin
! git fetch
$ git describe --tags --abbrev=0
$ git symbolic-ref HEAD
$ git for-each-ref --format="%(upstream:short)" refs/heads/master
$ git log --pretty=format:"* %s (%h)" 2020.11.25.1...HEAD
ERROR plugin.getIncrement is not a function
error Command failed with exit code 1.
```