### PR TITLE
Support calver 22.8.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,4 +21,37 @@ In [release-it](https://github.com/release-it/release-it) config:
 }
 ```
 
+#### Configuration examples:
+
+##### Defaults
+```json
+{
+    "format": "yy.mm.minor",
+    "increment": "calendar",
+    "fallbackIncrement": "minor"
+}
+```
+##### Output in November and December 2024
+```
+2024.11.0
+2024.11.1
+2024.12.1
+2024.12.2
+```
+
+##### Custom
+```json
+{
+    "format": "yyyy.mm.minor",
+    "increment": "calendar.minor"
+}
+```
+##### Output in November and December 2024
+```
+2024.11.0
+2024.11.1
+2024.12.0
+2024.12.1
+```
+
 More information on available format tags can be found here: [calver](https://github.com/muratgozel/node-calver)

--- a/calver-plugin-tests.js
+++ b/calver-plugin-tests.js
@@ -54,6 +54,18 @@ describe('plugin', function () {
     expect(incrementedVersion).to.equal('2021.1.1.0-alpha.1');
   });
 
+  it('should support both calendar and semantic tags in increment', function () {
+    const now = new Date();
+    const latestVersion = '21.1.5';
+    const plugin = new CalverPlugin();
+    plugin.setContext({'increment': 'calendar.minor'});
+    const firstBump = plugin.getIncrementedVersion({latestVersion});
+    const secondBump = plugin.getIncrementedVersion({latestVersion: firstBump});
+    const incrementedVersions = [firstBump, secondBump];
+    const expectedVersions = [versionFromDate(now, 0), versionFromDate(now, 1)];
+    expect(incrementedVersions).deep.to.equal(expectedVersions);
+  });
+
   it('should work by calling getIncrement()', function () {
     const version = '2021.1.1.0';
     const plugin = new CalverPlugin();

--- a/calver-plugin.js
+++ b/calver-plugin.js
@@ -22,10 +22,15 @@ class CalverPlugin extends Plugin {
 
     getIncrementedVersion(args) {
         const {latestVersion} = args || {};
-        const incrementedVersion = calver.inc(this.getFormat(), latestVersion, this.getInc());
-        return incrementedVersion === latestVersion ? 
-          calver.inc(this.getFormat(), latestVersion, this.getFallbackInc()): 
-          incrementedVersion;
+        try {
+            return calver.inc(this.getFormat(), latestVersion, this.getInc());
+        } catch {
+            try {
+                return calver.inc(this.getFormat(), latestVersion, this.getFallbackInc());
+            } catch {
+                return latestVersion;
+            }
+        }
     }
 
     getIncrementedVersionCI() {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "homepage": "https://github.com/casmith/release-it-calver-plugin#readme",
   "type": "module",
   "dependencies": {
-    "calver": "^21.11.3",
+    "calver": "^22.8.4",
     "chai": "^4.2.0",
     "mocha": "^10.0.0"
   },


### PR DESCRIPTION
- Updated node-calver
- Used multiple try/catches to attempt to preserve the current behaviour
  - Fallback if first attempt does not result in a change
  - Return initial version if second attempt does not result in a change
- Added test for combined calendar and semantic tags in increment option
- Added examples for config to README