### PR TITLE
fix: no existing tags creates a 0.0.0 format tag

### DIFF
--- a/calver-plugin-tests.js
+++ b/calver-plugin-tests.js
@@ -80,5 +80,14 @@ describe('plugin', function () {
     plugin.setContext({'increment': 'minor', 'format': 'yyyy.mm.minor.patch'});
     const incrementedVersion = plugin.getIncrementedVersionCI({latestVersion: version});
     expect(incrementedVersion).to.equal('2021.1.2.0');
-  });    
+  });
+
+  it('should increment version without existing tags', function () {
+    const plugin = new CalverPlugin();
+    plugin.setContext({ increment: 'minor', format: 'yyyy.mm.minor.patch' });
+    const incrementedVersion = plugin.getIncrementedVersion({
+      latestVersion: '',
+    });
+    expect(incrementedVersion).to.equal(versionFromDate(new Date(), 1));
+  });
 });


### PR DESCRIPTION
I've created a test which showcases the issue. This is the results from the test:

```bash
 1) plugin
       should increment version without existing tags:

      AssertionError: expected '0.0.1.0' to equal '24.2.1'
      + expected - actual

      -0.0.1.0
      +24.2.1
```

closes #37 